### PR TITLE
Add fallback to check uniqueness if signers are not ordered

### DIFF
--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -115,6 +115,7 @@ library SignatureChecker {
         for (uint256 i = 0; i < signers.length; ++i) {
             bytes memory signer = signers[i];
 
+            // If one of the signatures is invalid, reject the batch
             if (!isValidERC7913SignatureNow(signer, hash, signatures[i])) return false;
 
             bytes32 id = keccak256(signer);

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -120,10 +120,11 @@ library SignatureChecker {
             bytes32 id = keccak256(signer);
             if (lastId < id) {
                 lastId = id;
-            } else
+            } else {
                 for (uint256 j = 0; j < i; ++j) {
                     if (id == keccak256(signers[j])) return false;
                 }
+            }
         }
 
         return true;

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -118,7 +118,7 @@ library SignatureChecker {
             if (!isValidERC7913SignatureNow(signer, hash, signatures[i])) return false;
 
             bytes32 id = keccak256(signer);
-            // if the current signer id is greater than all previous signer ids, the this is a new signer.
+            // If the current signer ID is greater than all previous IDs, then this is a new signer.
             if (lastId < id) {
                 lastId = id;
             } else {

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -118,9 +118,12 @@ library SignatureChecker {
             if (!isValidERC7913SignatureNow(signer, hash, signatures[i])) return false;
 
             bytes32 id = keccak256(signer);
+            // if the current signer id is greater than all previous signer ids, the this is a new signer.
             if (lastId < id) {
                 lastId = id;
             } else {
+                // If this signer id is not greater than all the previous ones, verify that it is not a duplicate of a previous one
+                // This loop is never executed if the signers are ordered by id.
                 for (uint256 j = 0; j < i; ++j) {
                     if (id == keccak256(signers[j])) return false;
                 }

--- a/contracts/utils/cryptography/SignatureChecker.sol
+++ b/contracts/utils/cryptography/SignatureChecker.sol
@@ -95,8 +95,8 @@ library SignatureChecker {
     /**
      * @dev Verifies multiple ERC-7913 `signatures` for a given `hash` using a set of `signers`.
      *
-     * The signers must be ordered by their `keccak256` hash to ensure no duplicates and to optimize
-     * the verification process. The function will return `false` if the signers are not properly ordered.
+     * The signers should be ordered by their `keccak256` hash to ensure efficient duplication check. Unordered
+     * signers are supported, but the uniqueness check will be more expensive.
      *
      * Requirements:
      *
@@ -110,17 +110,20 @@ library SignatureChecker {
         bytes[] memory signers,
         bytes[] memory signatures
     ) internal view returns (bool) {
-        bytes32 previousId = bytes32(0);
+        bytes32 lastId = bytes32(0);
 
         for (uint256 i = 0; i < signers.length; ++i) {
             bytes memory signer = signers[i];
-            // Signers must ordered by id to ensure no duplicates
-            bytes32 id = keccak256(signer);
-            if (previousId >= id || !isValidERC7913SignatureNow(signer, hash, signatures[i])) {
-                return false;
-            }
 
-            previousId = id;
+            if (!isValidERC7913SignatureNow(signer, hash, signatures[i])) return false;
+
+            bytes32 id = keccak256(signer);
+            if (lastId < id) {
+                lastId = id;
+            } else
+                for (uint256 j = 0; j < i; ++j) {
+                    if (id == keccak256(signers[j])) return false;
+                }
         }
 
         return true;


### PR DESCRIPTION
Implement a fallback mechanism to check uniqueness even if signers are not ordered.

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [ ] Documentation
- [ ] Changeset entry (run `npx changeset add`)
