### PR TITLE
Refactor internal construction of ERC7540Deposit and ERC7540Redeem

### DIFF
--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -8,6 +8,8 @@ import {ERC7540Redeem} from "./ERC7540Redeem.sol";
 import {ERC7540Operator} from "./ERC7540Operator.sol";
 import {ERC20Vault} from "./ERC20Vault.sol";
 import {IERC20Vault} from "./IERC20Vault.sol";
+import {ERC20} from "./../ERC20.sol";
+import {IERC20} from "./../IERC20.sol";
 import {ERC165} from "../../../utils/introspection/ERC165.sol";
 /**
  * @dev Implementation of the ERC-7540 "Asynchronous ERC-4626 Tokenized Vaults" as defined in
@@ -24,6 +26,11 @@ import {ERC165} from "../../../utils/introspection/ERC165.sol";
  * Users should be cautious when approving operators as they gain significant control over both assets and shares.
  */
 abstract contract ERC7540 is ERC165, ERC7540Redeem, ERC7540Deposit, IERC4626 {
+    /// @inheritdoc ERC7540Redeem
+    function totalSupply() public view virtual override(ERC7540Redeem, ERC20, IERC20) returns (uint256) {
+        return super.totalSupply();
+    }
+
     /// @inheritdoc ERC7540Deposit
     function totalAssets() public view virtual override(ERC7540Deposit, ERC20Vault, IERC20Vault) returns (uint256) {
         return super.totalAssets();

--- a/contracts/token/ERC20/extensions/ERC7540Deposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Deposit.sol
@@ -106,9 +106,13 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         uint256 assets,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 shares) {
-        (assets, shares) = _claimDeposit(assets, 0, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        // *preview* and execute
+        uint256 shares = Math.mulDiv(assets, maxMint(controller), maxDeposit(controller), Math.Rounding.Floor);
+        _claimDeposit(assets, shares, receiver, controller);
+
         _mint(receiver, shares);
+
         return shares;
     }
 
@@ -129,9 +133,13 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         uint256 shares,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 assets) {
-        (assets, shares) = _claimDeposit(0, shares, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        // *preview* and execute
+        uint256 assets = Math.mulDiv(shares, maxDeposit(controller), maxMint(controller), Math.Rounding.Ceil);
+        _claimDeposit(assets, shares, receiver, controller);
+
         _mint(receiver, shares);
+
         return assets;
     }
 
@@ -214,7 +222,7 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
      *
      * * `assets` must not exceed the pending deposit amount for the controller
      */
-    function _fulfillDeposit(uint256 assets, uint256 shares, address controller) internal virtual returns (uint256) {
+    function _fulfillDeposit(uint256 assets, uint256 shares, address controller) internal virtual {
         uint256 pendingAssets = pendingDepositRequest(0, controller);
         require(assets <= pendingAssets, ERC7540DepositInsufficientPendingAssets(assets, pendingAssets));
 
@@ -223,39 +231,13 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         _deposits[controller].claimableShares += shares;
 
         emit DepositClaimable(controller, 0, assets, shares);
-        return shares;
     }
 
-    function _claimDeposit(
-        uint256 assets,
-        uint256 shares,
-        address receiver,
-        address controller
-    ) internal virtual returns (uint256, uint256) {
-        require(assets * shares == 0); // internal error;
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 claimableShares = maxMint(controller);
-        uint256 claimableAssets = maxDeposit(controller);
-        uint256 assetsUp;
-        uint256 sharesUp;
-
-        if (shares == 0) {
-            shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
-            sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
-            assetsUp = assets;
-        } else {
-            assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
-            assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
-            sharesUp = shares;
-        }
-
-        _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assetsUp);
-        _deposits[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
-        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
+    function _claimDeposit(uint256 assets, uint256 shares, address receiver, address controller) internal virtual {
+        _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assets);
+        _deposits[controller].claimableAssets = Math.saturatingSub(_deposits[controller].claimableAssets, assets);
+        _deposits[controller].claimableShares = Math.saturatingSub(_deposits[controller].claimableShares, shares);
 
         emit IERC4626.Deposit(controller, receiver, assets, shares);
-        return (assets, shares);
     }
 }

--- a/contracts/token/ERC20/extensions/ERC7540Deposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Deposit.sol
@@ -48,14 +48,14 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
     mapping(address controller => PendingDeposit) private _deposits;
     uint256 private _totalPendingDepositAssets;
 
-    /**
-     * @dev See {IERC20Vault-totalAssets}.
-     *
-     * Total assets pending redemption must be removed from the reported total assets
-     * otherwise pending assets would be treated as yield for outstanding shares.
-     */
-    function totalAssets() public view virtual override returns (uint256) {
-        return super.totalAssets() - totalPendingDepositAssets();
+    /****************************************************************************************************************
+     *                          Generic ERC-7540 behavior, applies to all implementations                           *
+     ****************************************************************************************************************/
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, ERC7540Operator) returns (bool) {
+        return interfaceId == type(IERC7540Deposit).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /// @dev See {IERC4626-previewDeposit}.
@@ -66,6 +66,88 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
     /// @dev See {IERC4626-previewMint}.
     function previewMint(uint256 /* shares */) public view virtual returns (uint256) {
         revert ERC7540DepositPreviewNotAvailable();
+    }
+
+    /**
+     * @dev See {IERC7540Deposit-requestDeposit}.
+     *
+     * NOTE: Pending accounting is updated before {_transferIn} to follow Checks-Effects-Interactions.
+     * Assets with transfer hooks (e.g. ERC-777) may observe {totalAssets} temporarily understated
+     * during the transfer, since `_totalPendingDepositAssets` is already incremented while the
+     * token balance has not yet increased.
+     */
+    function requestDeposit(
+        uint256 assets,
+        address controller,
+        address owner
+    ) public virtual onlyOperatorOrController(owner, _msgSender()) returns (uint256) {
+        // Must revert with ERC20InsufficientBalance or equivalent error if there's not enough balance.
+        _transferIn(owner, assets);
+
+        return _requestDeposit(assets, controller, owner);
+    }
+
+    /**
+     * @dev Allows claiming shares from a Claimable deposit request.
+     * Calls the three-argument version with `receiver` as the `controller`. Complies with ERC-4626.
+     *
+     * See {IERC7540Deposit-deposit}.
+     *
+     * NOTE: this function should be overridden. To modify the behavior, override {IERC7540Deposit-deposit} instead.
+     */
+    function deposit(uint256 assets, address receiver) public virtual returns (uint256 shares) {
+        return deposit(assets, receiver, _msgSender());
+    }
+
+    /// @inheritdoc IERC7540Deposit
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address controller
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        uint256 shares = _deposit(assets, receiver, controller);
+        _mint(receiver, shares);
+        return shares;
+    }
+
+    /**
+     * @dev Allows claiming shares from a Claimable deposit request by specifying the exact amount of shares.
+     * Calls the three-argument version with `receiver` as the `controller`. Complies with ERC-4626.
+     *
+     * See {IERC7540Deposit-mint}.
+     *
+     * NOTE: this function should be overridden. To modify the behavior, override {IERC7540Deposit-deposit} instead.
+     */
+    function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
+        return mint(shares, receiver, _msgSender());
+    }
+
+    /// @inheritdoc IERC7540Deposit
+    function mint(
+        uint256 shares,
+        address receiver,
+        address controller
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        uint256 assets = _mint(shares, receiver, controller);
+        _mint(receiver, shares);
+        return assets;
+    }
+
+    /****************************************************************************************************************
+     *                              Behavior specific to this ERC-7540 implementation                               *
+     *                                                                                                              *
+     * There should be overridden to modify the behavior of the vault, for example to introduce different requestId *
+     * to enforce delays on the asynchronous operations or to use a different storage for tracking.                 *
+     ****************************************************************************************************************/
+
+    /**
+     * @dev See {ERC4626-totalAssets}.
+     *
+     * Total assets pending redemption must be removed from the reported total assets
+     * otherwise pending assets would be treated as yield for outstanding shares.
+     */
+    function totalAssets() public view virtual override returns (uint256) {
+        return super.totalAssets() - totalPendingDepositAssets();
     }
 
     /// @dev Returns the total amount of assets currently pending in deposit requests.
@@ -86,7 +168,7 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         return _deposits[controller].claimableAssets;
     }
 
-    /// @dev Shares locked in the claimable deposit request.
+    /// TODO: non standard.
     function claimableDepositRequestShares(
         uint256 /* requestId */,
         address controller
@@ -96,165 +178,81 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
 
     /// @inheritdoc IERC20Vault
     function maxDeposit(address controller) public view virtual override returns (uint256) {
-        return claimableDepositRequest(_depositRequestId(controller), controller);
+        return _deposits[controller].claimableAssets;
     }
 
     /// @inheritdoc IERC20Vault
     function maxMint(address controller) public view virtual override returns (uint256) {
-        return claimableDepositRequestShares(_depositRequestId(controller), controller);
-    }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165, ERC7540Operator) returns (bool) {
-        return interfaceId == type(IERC7540Deposit).interfaceId || super.supportsInterface(interfaceId);
+        return _deposits[controller].claimableShares;
     }
 
     /**
-     * @dev See {IERC7540Deposit-requestDeposit}.
+     * @dev Registers a new deposit request in Pending state by recording the requested assets and updating the pending accounting.
      *
-     * NOTE: Pending accounting is updated before {_transferIn} to follow Checks-Effects-Interactions.
-     * Assets with transfer hooks (e.g. ERC-777) may observe {totalAssets} temporarily understated
-     * during the transfer, since `_totalPendingDepositAssets` is already incremented while the
-     * token balance has not yet increased.
+     * Note: `assets` have already been transferred to the vault before calling this function.
      */
-    function requestDeposit(
-        uint256 assets,
-        address controller,
-        address owner
-    ) public virtual onlyOperatorOrController(owner, _msgSender()) returns (uint256) {
-        uint256 requestId = _depositRequestId(controller);
-        _setPendingDeposit(controller, assets + pendingDepositRequest(requestId, controller));
+    function _requestDeposit(uint256 assets, address controller, address owner) internal virtual returns (uint256) {
+        // track pending deposits
+        _deposits[controller].pendingAssets += assets;
         _totalPendingDepositAssets += assets;
 
-        // Must revert with ERC20InsufficientBalance or equivalent error if there's not enough balance.
-        _transferIn(owner, assets);
-        emit DepositRequest(controller, owner, requestId, _msgSender(), assets);
-        return requestId;
-    }
-
-    /**
-     * @dev Allows claiming shares from a Claimable deposit request.
-     * Calls the three-argument version with `receiver` as the `controller`. Complies with ERC-4626.
-     *
-     * See {IERC7540Deposit-deposit}.
-     */
-    function deposit(uint256 assets, address receiver) public virtual returns (uint256 shares) {
-        return deposit(assets, receiver, receiver);
-    }
-
-    /// @inheritdoc IERC7540Deposit
-    function deposit(
-        uint256 assets,
-        address receiver,
-        address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 requestId = _depositRequestId(controller);
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 requestShares = claimableDepositRequestShares(requestId, controller);
-        uint256 requestAssets = claimableDepositRequest(requestId, controller);
-        uint256 shares = Math.mulDiv(assets, requestShares, requestAssets, Math.Rounding.Floor);
-        uint256 sharesUp = Math.mulDiv(assets, requestShares, requestAssets, Math.Rounding.Ceil);
-
-        _setClaimableDeposit(
-            controller,
-            requestAssets - assets,
-            Math.ternary(requestShares > sharesUp, requestShares - sharesUp, 0)
-        );
-        _update(address(this), receiver, shares);
-
-        emit IERC4626.Deposit(controller, receiver, assets, shares);
-        return shares;
-    }
-
-    /**
-     * @dev Allows claiming shares from a Claimable deposit request by specifying the exact amount of shares.
-     * Calls the three-argument version with `receiver` as the `controller`. Complies with ERC-4626.
-     *
-     * See {IERC7540Deposit-mint}.
-     */
-    function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
-        return mint(shares, receiver, receiver);
-    }
-
-    /// @inheritdoc IERC7540Deposit
-    function mint(
-        uint256 shares,
-        address receiver,
-        address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 requestId = _depositRequestId(controller);
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 requestAssets = claimableDepositRequest(requestId, controller);
-        uint256 requestShares = claimableDepositRequestShares(requestId, controller);
-        uint256 assets = Math.mulDiv(shares, requestAssets, requestShares, Math.Rounding.Floor);
-        uint256 assetsUp = Math.mulDiv(shares, requestAssets, requestShares, Math.Rounding.Ceil);
-
-        _setClaimableDeposit(
-            controller,
-            Math.ternary(requestAssets > assetsUp, requestAssets - assetsUp, 0),
-            requestShares - shares
-        );
-        _update(address(this), receiver, shares);
-
-        emit IERC4626.Deposit(controller, receiver, assets, shares);
-        return assets;
+        emit DepositRequest(controller, owner, 0, _msgSender(), assets);
+        return 0;
     }
 
     /**
      * @dev Fulfills a pending deposit request by transitioning it from Pending to Claimable state.
      *
-     * This internal function should be called by the vault implementation when it's ready to process
-     * a deposit request. It converts the specified amount of pending assets to shares at the current
-     * exchange rate, mints those shares to the vault itself, and updates the claimable balance for
-     * the controller.
-     *
-     * The shares are minted to the vault contract and held there until the controller claims them
-     * via {deposit} or {mint}.
+     * This internal function should be called by the vault implementation when it's ready to process a deposit
+     * request. Arguments provide the exchange rate at which the operation is fulfilled, which may be different from
+     * the overall vault exchange rate. As documented in ERC-7540, it may also be different from the exchange rate at
+     * the time of the request.
      *
      * Requirements:
      *
      * * `assets` must not exceed the pending deposit amount for the controller
      */
-    function _fulfillDeposit(uint256 assets, address controller) internal virtual returns (uint256) {
-        uint256 requestId = _depositRequestId(controller);
-        uint256 pendingAssets = pendingDepositRequest(requestId, controller);
+    function _fulfillDeposit(uint256 assets, uint256 shares, address controller) internal virtual returns (uint256) {
+        uint256 pendingAssets = pendingDepositRequest(0, controller);
         require(assets <= pendingAssets, ERC7540DepositInsufficientPendingAssets(assets, pendingAssets));
 
-        uint256 shares = _depositPrice(assets);
-        uint256 claimableAssets = claimableDepositRequest(requestId, controller);
-        uint256 claimableShares = claimableDepositRequestShares(requestId, controller);
-        _mint(address(this), shares);
-        _setClaimableDeposit(controller, claimableAssets + assets, claimableShares + shares);
-        _setPendingDeposit(controller, pendingAssets - assets);
-        _totalPendingDepositAssets -= assets;
-        emit DepositClaimable(controller, requestId, assets, shares);
+        _deposits[controller].pendingAssets -= assets;
+        _deposits[controller].claimableAssets += assets;
+        _deposits[controller].claimableShares += shares;
+
+        emit DepositClaimable(controller, 0, assets, shares);
         return shares;
     }
 
-    /// @dev Returns the price of depositing the given assets.
-    function _depositPrice(uint256 assets) internal view virtual returns (uint256) {
-        return convertToShares(assets);
+    function _deposit(uint256 assets, address receiver, address controller) internal virtual returns (uint256) {
+        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
+        // while the claimable balance is reduced by a rounded up amount.
+        uint256 claimableShares = maxMint(controller);
+        uint256 claimableAssets = maxDeposit(controller);
+        uint256 shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
+        uint256 sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
+
+        _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assets);
+        _deposits[controller].claimableAssets = Math.saturatingSub(claimableAssets, assets);
+        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
+
+        emit IERC4626.Deposit(controller, receiver, assets, shares);
+        return shares;
     }
 
-    /// @dev Sets the claimable deposit request for the controller.
-    function _setClaimableDeposit(address controller, uint256 assets, uint256 shares) internal virtual {
-        _deposits[controller].claimableAssets = assets;
-        _deposits[controller].claimableShares = shares;
-    }
+    function _mint(uint256 shares, address receiver, address controller) internal virtual returns (uint256) {
+        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
+        // while the claimable balance is reduced by a rounded up amount.
+        uint256 claimableShares = maxMint(controller);
+        uint256 claimableAssets = maxDeposit(controller);
+        uint256 assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
+        uint256 assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
 
-    /// @dev Sets the pending deposit request for the controller.
-    function _setPendingDeposit(address controller, uint256 assets) internal virtual {
-        _deposits[controller].pendingAssets = assets;
-    }
+        _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assetsUp);
+        _deposits[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
+        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, shares);
 
-    /// @dev Returns the request ID for the given assets, controller, and owner
-    function _depositRequestId(address /* controller */) internal view virtual returns (uint256) {
-        return 0; // Assume requests are non-fungible and all have ID = 0
+        emit IERC4626.Deposit(controller, receiver, assets, shares);
+        return assets;
     }
 }

--- a/contracts/token/ERC20/extensions/ERC7540Deposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Deposit.sol
@@ -81,10 +81,12 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         address controller,
         address owner
     ) public virtual onlyOperatorOrController(owner, _msgSender()) returns (uint256) {
+        uint256 requestId = _requestDeposit(assets, controller, owner);
+
         // Must revert with ERC20InsufficientBalance or equivalent error if there's not enough balance.
         _transferIn(owner, assets);
 
-        return _requestDeposit(assets, controller, owner);
+        return requestId;
     }
 
     /**
@@ -104,8 +106,8 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         uint256 assets,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 shares = _deposit(assets, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 shares) {
+        (assets, shares) = _claimDeposit(assets, 0, receiver, controller);
         _mint(receiver, shares);
         return shares;
     }
@@ -127,8 +129,8 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         uint256 shares,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 assets = _mint(shares, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 assets) {
+        (assets, shares) = _claimDeposit(0, shares, receiver, controller);
         _mint(receiver, shares);
         return assets;
     }
@@ -224,35 +226,36 @@ abstract contract ERC7540Deposit is ERC165, ERC7540Operator, IERC7540Deposit {
         return shares;
     }
 
-    function _deposit(uint256 assets, address receiver, address controller) internal virtual returns (uint256) {
+    function _claimDeposit(
+        uint256 assets,
+        uint256 shares,
+        address receiver,
+        address controller
+    ) internal virtual returns (uint256, uint256) {
+        require(assets * shares == 0); // internal error;
+
         // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
         // while the claimable balance is reduced by a rounded up amount.
         uint256 claimableShares = maxMint(controller);
         uint256 claimableAssets = maxDeposit(controller);
-        uint256 shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
-        uint256 sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
+        uint256 assetsUp;
+        uint256 sharesUp;
 
-        _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assets);
-        _deposits[controller].claimableAssets = Math.saturatingSub(claimableAssets, assets);
-        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
-
-        emit IERC4626.Deposit(controller, receiver, assets, shares);
-        return shares;
-    }
-
-    function _mint(uint256 shares, address receiver, address controller) internal virtual returns (uint256) {
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 claimableShares = maxMint(controller);
-        uint256 claimableAssets = maxDeposit(controller);
-        uint256 assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
-        uint256 assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
+        if (shares == 0) {
+            shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
+            sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
+            assetsUp = assets;
+        } else {
+            assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
+            assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
+            sharesUp = shares;
+        }
 
         _totalPendingDepositAssets = Math.saturatingSub(_totalPendingDepositAssets, assetsUp);
         _deposits[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
-        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, shares);
+        _deposits[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
 
         emit IERC4626.Deposit(controller, receiver, assets, shares);
-        return assets;
+        return (assets, shares);
     }
 }

--- a/contracts/token/ERC20/extensions/ERC7540Operator.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Operator.sol
@@ -45,14 +45,14 @@ abstract contract ERC7540Operator is ERC165, ERC20Vault, IERC7540Operator {
      */
     constructor(IERC20 asset_) ERC20Vault(asset_) {}
 
-    /// @inheritdoc IERC7540Operator
-    function isOperator(address controller, address operator) public view returns (bool status) {
-        return _isOperator[controller][operator];
-    }
-
     /// @inheritdoc ERC165
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IERC7540Operator).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IERC7540Operator
+    function isOperator(address controller, address operator) public view returns (bool status) {
+        return _isOperator[controller][operator];
     }
 
     /// @inheritdoc IERC7540Operator
@@ -67,10 +67,8 @@ abstract contract ERC7540Operator is ERC165, ERC20Vault, IERC7540Operator {
      * Emits an {OperatorSet} event if the approval status changes.
      */
     function _setOperator(address controller, address operator, bool approved) internal {
-        if (_isOperator[controller][operator] != approved) {
-            _isOperator[controller][operator] = approved;
-            emit OperatorSet(controller, operator, approved);
-        }
+        _isOperator[controller][operator] = approved;
+        emit OperatorSet(controller, operator, approved);
     }
 
     /// @dev Reverts if the `operator` is not the caller or an operator of the `controller`

--- a/contracts/token/ERC20/extensions/ERC7540Redeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Redeem.sol
@@ -99,7 +99,7 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
     ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
         // *preview* and execute
         uint256 shares = Math.mulDiv(assets, maxRedeem(controller), maxWithdraw(controller), Math.Rounding.Ceil);
-        _claimRedeem(assets, 0, receiver, controller);
+        _claimRedeem(assets, shares, receiver, controller);
 
         _transferOut(receiver, assets);
 
@@ -121,7 +121,7 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
     ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
         // *preview* and execute
         uint256 assets = Math.mulDiv(shares, maxWithdraw(controller), maxRedeem(controller), Math.Rounding.Floor);
-        _claimRedeem(0, shares, receiver, controller);
+        _claimRedeem(assets, shares, receiver, controller);
 
         _transferOut(receiver, assets);
 

--- a/contracts/token/ERC20/extensions/ERC7540Redeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Redeem.sol
@@ -96,8 +96,8 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         uint256 assets,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 shares = _withdraw(assets, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 shares) {
+        (assets, shares) = _claimRedeem(assets, 0, receiver, controller);
         _transferOut(receiver, assets);
         return shares;
     }
@@ -114,8 +114,8 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         uint256 shares,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 assets = _redeem(shares, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 assets) {
+        (assets, shares) = _claimRedeem(0, shares, receiver, controller);
         _transferOut(receiver, assets);
         return assets;
     }
@@ -231,19 +231,36 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         return shares;
     }
 
-    function _redeem(uint256 shares, address receiver, address controller) internal virtual returns (uint256) {
+    function _claimRedeem(
+        uint256 assets,
+        uint256 shares,
+        address receiver,
+        address controller
+    ) internal virtual returns (uint256, uint256) {
+        require(assets * shares == 0); // internal error
+
         // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
         // while the claimable balance is reduced by a rounded up amount.
         uint256 claimableAssets = maxWithdraw(controller);
         uint256 claimableShares = maxRedeem(controller);
-        uint256 assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
-        uint256 assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
+        uint256 assetsUp;
+        uint256 sharesUp;
 
-        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, shares);
-        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, shares);
+        if (shares == 0) {
+            shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
+            sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
+            assetsUp = assets;
+        } else {
+            assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
+            assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
+            sharesUp = shares;
+        }
+
+        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, sharesUp);
+        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
         _redeems[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
 
         emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
-        return assets;
+        return (assets, shares);
     }
 }

--- a/contracts/token/ERC20/extensions/ERC7540Redeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Redeem.sol
@@ -215,22 +215,6 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         return assets;
     }
 
-    function _withdraw(uint256 assets, address receiver, address controller) internal virtual returns (uint256) {
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 claimableShares = maxRedeem(controller);
-        uint256 claimableAssets = maxWithdraw(controller);
-        uint256 shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
-        uint256 sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
-
-        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, sharesUp);
-        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
-        _redeems[controller].claimableAssets = Math.saturatingSub(claimableAssets, assets);
-
-        emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
-        return shares;
-    }
-
     function _claimRedeem(
         uint256 assets,
         uint256 shares,

--- a/contracts/token/ERC20/extensions/ERC7540Redeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Redeem.sol
@@ -96,9 +96,13 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         uint256 assets,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 shares) {
-        (assets, shares) = _claimRedeem(assets, 0, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        // *preview* and execute
+        uint256 shares = Math.mulDiv(assets, maxRedeem(controller), maxWithdraw(controller), Math.Rounding.Ceil);
+        _claimRedeem(assets, 0, receiver, controller);
+
         _transferOut(receiver, assets);
+
         return shares;
     }
 
@@ -114,9 +118,13 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         uint256 shares,
         address receiver,
         address controller
-    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256 assets) {
-        (assets, shares) = _claimRedeem(0, shares, receiver, controller);
+    ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
+        // *preview* and execute
+        uint256 assets = Math.mulDiv(shares, maxWithdraw(controller), maxRedeem(controller), Math.Rounding.Floor);
+        _claimRedeem(0, shares, receiver, controller);
+
         _transferOut(receiver, assets);
+
         return assets;
     }
 
@@ -203,7 +211,7 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
      *
      * * `shares` must not exceed the pending redeem amount for the controller
      */
-    function _fulfillRedeem(uint256 shares, uint256 assets, address controller) internal virtual returns (uint256) {
+    function _fulfillRedeem(uint256 shares, uint256 assets, address controller) internal virtual {
         uint256 pendingShares = pendingRedeemRequest(0, controller);
         require(shares <= pendingShares, ERC7540RedeemInsufficientPendingShares(shares, pendingShares));
 
@@ -212,39 +220,13 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         _redeems[controller].claimableAssets += assets;
 
         emit RedeemClaimable(controller, 0, assets, shares);
-        return assets;
     }
 
-    function _claimRedeem(
-        uint256 assets,
-        uint256 shares,
-        address receiver,
-        address controller
-    ) internal virtual returns (uint256, uint256) {
-        require(assets * shares == 0); // internal error
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 claimableAssets = maxWithdraw(controller);
-        uint256 claimableShares = maxRedeem(controller);
-        uint256 assetsUp;
-        uint256 sharesUp;
-
-        if (shares == 0) {
-            shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
-            sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
-            assetsUp = assets;
-        } else {
-            assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
-            assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
-            sharesUp = shares;
-        }
-
-        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, sharesUp);
-        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
-        _redeems[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
+    function _claimRedeem(uint256 assets, uint256 shares, address receiver, address controller) internal virtual {
+        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, shares);
+        _redeems[controller].claimableShares = Math.saturatingSub(_redeems[controller].claimableShares, shares);
+        _redeems[controller].claimableAssets = Math.saturatingSub(_redeems[controller].claimableAssets, assets);
 
         emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
-        return (assets, shares);
     }
 }

--- a/contracts/token/ERC20/extensions/ERC7540Redeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540Redeem.sol
@@ -51,6 +51,17 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
     }
 
     mapping(address controller => PendingRedeem) private _redeems;
+    uint256 private _totalPendingRedeemShares;
+
+    /****************************************************************************************************************
+     *                          Generic ERC-7540 behavior, applies to all implementations                           *
+     ****************************************************************************************************************/
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, ERC7540Operator) returns (bool) {
+        return interfaceId == type(IERC7540Redeem).interfaceId || super.supportsInterface(interfaceId);
+    }
 
     /// @dev See {IERC4626-previewRedeem}.
     function previewRedeem(uint256 /* shares */) public view virtual returns (uint256) {
@@ -63,54 +74,14 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
     }
 
     /// @inheritdoc IERC7540Redeem
-    function pendingRedeemRequest(uint256 /* requestId */, address controller) public view virtual returns (uint256) {
-        return _redeems[controller].pendingShares;
-    }
-
-    /// @inheritdoc IERC7540Redeem
-    function claimableRedeemRequest(uint256 /* requestId */, address controller) public view virtual returns (uint256) {
-        return _redeems[controller].claimableShares;
-    }
-
-    /// @dev Assets locked in the claimable redeem request.
-    function claimableRedeemRequestAssets(
-        uint256 /* requestId */,
-        address controller
-    ) public view virtual returns (uint256) {
-        return _redeems[controller].claimableAssets;
-    }
-
-    /// @inheritdoc IERC20Vault
-    function maxWithdraw(address controller) public view virtual override returns (uint256) {
-        return claimableRedeemRequestAssets(_redeemRequestId(controller), controller);
-    }
-
-    /// @inheritdoc IERC20Vault
-    function maxRedeem(address controller) public view virtual override returns (uint256) {
-        return claimableRedeemRequest(_redeemRequestId(controller), controller);
-    }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165, ERC7540Operator) returns (bool) {
-        return interfaceId == type(IERC7540Redeem).interfaceId || super.supportsInterface(interfaceId);
-    }
-
-    /// @inheritdoc IERC7540Redeem
     function requestRedeem(uint256 shares, address controller, address owner) public virtual returns (uint256) {
         address sender = _msgSender();
         if (owner != sender && !isOperator(owner, sender)) {
             _spendAllowance(owner, sender, shares);
         }
+        _burn(owner, shares);
 
-        uint256 requestId = _redeemRequestId(controller);
-        _setPendingRedeem(controller, shares + pendingRedeemRequest(requestId, controller));
-
-        // Must revert with ERC20InsufficientBalance if there's not enough balance.
-        _lockSharesIn(shares, owner);
-        emit RedeemRequest(controller, owner, requestId, sender, shares);
-        return requestId;
+        return _requestRedeem(shares, controller, owner);
     }
 
     /**
@@ -126,23 +97,8 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         address receiver,
         address controller
     ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 requestId = _redeemRequestId(controller);
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 requestShares = claimableRedeemRequest(requestId, controller);
-        uint256 requestAssets = claimableRedeemRequestAssets(requestId, controller);
-        uint256 shares = Math.mulDiv(assets, requestShares, requestAssets, Math.Rounding.Floor);
-        uint256 sharesUp = Math.mulDiv(assets, requestShares, requestAssets, Math.Rounding.Ceil);
-
-        _setClaimableRedeem(
-            controller,
-            requestAssets - assets,
-            Math.ternary(requestShares > sharesUp, requestShares - sharesUp, 0)
-        );
+        uint256 shares = _withdraw(assets, receiver, controller);
         _transferOut(receiver, assets);
-
-        emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
         return shares;
     }
 
@@ -159,24 +115,73 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
         address receiver,
         address controller
     ) public virtual onlyOperatorOrController(controller, _msgSender()) returns (uint256) {
-        uint256 requestId = _redeemRequestId(controller);
-
-        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
-        // while the claimable balance is reduced by a rounded up amount.
-        uint256 requestAssets = claimableRedeemRequestAssets(requestId, controller);
-        uint256 requestShares = claimableRedeemRequest(requestId, controller);
-        uint256 assets = Math.mulDiv(shares, requestAssets, requestShares, Math.Rounding.Floor);
-        uint256 assetsUp = Math.mulDiv(shares, requestAssets, requestShares, Math.Rounding.Ceil);
-
-        _setClaimableRedeem(
-            controller,
-            Math.ternary(requestAssets > assetsUp, requestAssets - assetsUp, 0),
-            requestShares - shares
-        );
+        uint256 assets = _redeem(shares, receiver, controller);
         _transferOut(receiver, assets);
-
-        emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
         return assets;
+    }
+
+    /****************************************************************************************************************
+     *                              Behavior specific to this ERC-7540 implementation                               *
+     *                                                                                                              *
+     * There should be overridden to modify the behavior of the vault, for example to introduce different requestId *
+     * to enforce delays on the asynchronous operations or to use a different storage for tracking.                 *
+     ****************************************************************************************************************/
+
+    /**
+     * @dev See {ERC4626-totalSupply}.
+     *
+     * Total shares pending redemption must be added from the reported total supply
+     * otherwise pending assets would be treated as yield for outstanding shares.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return super.totalSupply() + totalPendingRedeemShares();
+    }
+
+    /// @dev Returns the total amount of shares currently pending in redeem requests.
+    function totalPendingRedeemShares() public view virtual returns (uint256) {
+        return _totalPendingRedeemShares;
+    }
+
+    /// @inheritdoc IERC7540Redeem
+    function pendingRedeemRequest(uint256 /* requestId */, address controller) public view virtual returns (uint256) {
+        return _redeems[controller].pendingShares;
+    }
+
+    /// @inheritdoc IERC7540Redeem
+    function claimableRedeemRequest(uint256 /* requestId */, address controller) public view virtual returns (uint256) {
+        return _redeems[controller].claimableShares;
+    }
+
+    /// TODO: non standard
+    function claimableRedeemRequestAssets(
+        uint256 /* requestId */,
+        address controller
+    ) public view virtual returns (uint256) {
+        return _redeems[controller].claimableAssets;
+    }
+
+    /// @inheritdoc IERC20Vault
+    function maxWithdraw(address controller) public view virtual override returns (uint256) {
+        return _redeems[controller].claimableAssets;
+    }
+
+    /// @inheritdoc IERC20Vault
+    function maxRedeem(address controller) public view virtual override returns (uint256) {
+        return _redeems[controller].claimableShares;
+    }
+
+    /**
+     * @dev Registers a new redeem request in Pending state by recording the requested assets and updating the pending accounting.
+     *
+     * Note: `shares` have already been burned before calling this function.
+     */
+    function _requestRedeem(uint256 shares, address controller, address owner) internal virtual returns (uint256) {
+        // track pending redeem
+        _redeems[controller].pendingShares += shares;
+        _totalPendingRedeemShares += shares;
+
+        emit RedeemRequest(controller, owner, 0, _msgSender(), shares);
+        return 0;
     }
 
     /**
@@ -198,62 +203,47 @@ abstract contract ERC7540Redeem is ERC165, ERC7540Operator, IERC7540Redeem {
      *
      * * `shares` must not exceed the pending redeem amount for the controller
      */
-    function _fulfillRedeem(uint256 shares, address controller) internal virtual returns (uint256) {
-        uint256 requestId = _redeemRequestId(controller);
-        uint256 pendingShares = pendingRedeemRequest(requestId, controller);
+    function _fulfillRedeem(uint256 shares, uint256 assets, address controller) internal virtual returns (uint256) {
+        uint256 pendingShares = pendingRedeemRequest(0, controller);
         require(shares <= pendingShares, ERC7540RedeemInsufficientPendingShares(shares, pendingShares));
 
-        uint256 assets = _redeemPrice(shares);
-        uint256 claimableAssets = claimableRedeemRequestAssets(requestId, controller);
-        uint256 claimableShares = claimableRedeemRequest(requestId, controller);
-        _completeSharesIn(shares, controller);
-        _setClaimableRedeem(controller, claimableAssets + assets, claimableShares + shares);
-        _setPendingRedeem(controller, pendingShares - shares);
-        emit RedeemClaimable(controller, requestId, assets, shares);
+        _redeems[controller].pendingShares -= shares;
+        _redeems[controller].claimableShares += shares;
+        _redeems[controller].claimableAssets += assets;
+
+        emit RedeemClaimable(controller, 0, assets, shares);
         return assets;
     }
 
-    /**
-     * @dev Returns the asset amount corresponding to `shares` for a redemption fulfillment.
-     * Defaults to the live {convertToAssets} rate. Override this function to use a snapshotted
-     * or custom rate when batch-fulfilling multiple requests in {_fulfillRedeem}, since each
-     * fulfillment burns shares and shifts the live exchange rate upward.
-     */
-    function _redeemPrice(uint256 shares) internal view virtual returns (uint256) {
-        return convertToAssets(shares);
+    function _withdraw(uint256 assets, address receiver, address controller) internal virtual returns (uint256) {
+        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
+        // while the claimable balance is reduced by a rounded up amount.
+        uint256 claimableShares = maxRedeem(controller);
+        uint256 claimableAssets = maxWithdraw(controller);
+        uint256 shares = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Floor);
+        uint256 sharesUp = Math.mulDiv(assets, claimableShares, claimableAssets, Math.Rounding.Ceil);
+
+        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, sharesUp);
+        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, sharesUp);
+        _redeems[controller].claimableAssets = Math.saturatingSub(claimableAssets, assets);
+
+        emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
+        return shares;
     }
 
-    /// @dev Sets the claimable redeem request for the controller.
-    function _setClaimableRedeem(address controller, uint256 assets, uint256 shares) internal virtual {
-        _redeems[controller].claimableAssets = assets;
-        _redeems[controller].claimableShares = shares;
-    }
+    function _redeem(uint256 shares, address receiver, address controller) internal virtual returns (uint256) {
+        // Claiming partially introduces precision loss. The user therefore receives a rounded down amount,
+        // while the claimable balance is reduced by a rounded up amount.
+        uint256 claimableAssets = maxWithdraw(controller);
+        uint256 claimableShares = maxRedeem(controller);
+        uint256 assets = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Floor);
+        uint256 assetsUp = Math.mulDiv(shares, claimableAssets, claimableShares, Math.Rounding.Ceil);
 
-    /// @dev Sets the pending redeem request for the controller.
-    function _setPendingRedeem(address controller, uint256 shares) internal virtual {
-        _redeems[controller].pendingShares = shares;
-    }
+        _totalPendingRedeemShares = Math.saturatingSub(_totalPendingRedeemShares, shares);
+        _redeems[controller].claimableShares = Math.saturatingSub(claimableShares, shares);
+        _redeems[controller].claimableAssets = Math.saturatingSub(claimableAssets, assetsUp);
 
-    /**
-     * @dev Performs a transfer in of shares. By default, it takes the shares from the owner.
-     * Used by {requestRedeem}.
-     *
-     * IMPORTANT: If overriding to burn shares immediately (instead of holding them in the vault),
-     * you must ALSO override {_fulfillRedeem} to use a snapshotted exchange rate, since the
-     * shares will no longer exist in `totalSupply()` at fulfillment time. Simply overriding
-     * {_completeSharesIn} to do nothing is not sufficient.
-     */
-    function _lockSharesIn(uint256 shares, address owner) internal virtual {
-        _update(owner, address(this), shares);
-    }
-
-    /// @dev Performs a fulfillment of a redeem request. By default, it burns the shares. Used by {_fulfillRedeem}.
-    function _completeSharesIn(uint256 shares, address /* controller */) internal virtual {
-        _burn(address(this), shares);
-    }
-
-    /// @dev Returns the request ID for the given redeem parameters.
-    function _redeemRequestId(address /* controller */) internal view virtual returns (uint256) {
-        return 0; // Assume requests are non-fungible and all have ID = 0
+        emit IERC4626.Withdraw(_msgSender(), receiver, controller, assets, shares);
+        return assets;
     }
 }

--- a/test/token/ERC20/extensions/ERC7540.behavior.js
+++ b/test/token/ERC20/extensions/ERC7540.behavior.js
@@ -60,7 +60,7 @@ function shouldBehaveLikeERC7540Deposit() {
         await this.asset.$_mint(this.holder, depositAmount);
         await this.asset.connect(this.holder).approve(this.token, depositAmount);
         await this.token.connect(this.holder).requestDeposit(depositAmount, this.holder, this.holder);
-        await this.token.$_fulfillDeposit(depositAmount, this.holder);
+        await this.token.$_fulfillDeposit(depositAmount, this.token.convertToShares(depositAmount), this.holder);
 
         await expect(this.token.totalAssets()).to.eventually.equal(depositAmount);
       });
@@ -139,7 +139,7 @@ function shouldBehaveLikeERC7540Deposit() {
       });
 
       it('reverts when fulfilling more than pending', async function () {
-        await expect(this.token.$_fulfillDeposit(depositAmount + 1n, this.holder))
+        await expect(this.token.$_fulfillDeposit(depositAmount + 1n, 0n, this.holder))
           .to.be.revertedWithCustomError(this.token, 'ERC7540DepositInsufficientPendingAssets')
           .withArgs(depositAmount + 1n, depositAmount);
       });
@@ -147,7 +147,7 @@ function shouldBehaveLikeERC7540Deposit() {
       describe('full fulfillment', function () {
         beforeEach(async function () {
           this.expectedShares = depositAmount; // 1:1 exchange rate in empty vault
-          this.tx = await this.token.$_fulfillDeposit(depositAmount, this.holder);
+          this.tx = await this.token.$_fulfillDeposit(depositAmount, depositAmount, this.holder); // 1:1 exhange rate
         });
 
         it('emits DepositClaimable', async function () {
@@ -181,7 +181,7 @@ function shouldBehaveLikeERC7540Deposit() {
         const partialAmount = 400n;
 
         beforeEach(async function () {
-          this.tx = await this.token.$_fulfillDeposit(partialAmount, this.holder);
+          this.tx = await this.token.$_fulfillDeposit(partialAmount, partialAmount, this.holder); // 1:1 exhange rate
         });
 
         it('emits DepositClaimable for the partial amount', async function () {
@@ -204,7 +204,7 @@ function shouldBehaveLikeERC7540Deposit() {
         await this.asset.$_mint(this.holder, depositAmount);
         await this.asset.connect(this.holder).approve(this.token, depositAmount);
         await this.token.connect(this.holder).requestDeposit(depositAmount, this.holder, this.holder);
-        await this.token.$_fulfillDeposit(depositAmount, this.holder);
+        await this.token.$_fulfillDeposit(depositAmount, depositAmount, this.holder); // 1:1 exchange rate
         this.expectedShares = depositAmount; // 1:1 rate
       });
 
@@ -286,7 +286,7 @@ function shouldBehaveLikeERC7540Deposit() {
         await this.asset.$_mint(this.holder, depositAmount);
         await this.asset.connect(this.holder).approve(this.token, depositAmount);
         await this.token.connect(this.holder).requestDeposit(depositAmount, this.holder, this.holder);
-        await this.token.$_fulfillDeposit(depositAmount, this.holder);
+        await this.token.$_fulfillDeposit(depositAmount, depositAmount, this.holder); // 1:1 exchange rate
         this.expectedShares = depositAmount; // 1:1 rate
       });
 


### PR DESCRIPTION
### ERC7540Deposit

- do not mint share to the vault on fulfillDeposit. Instead, mint them directly to the recipient on the `deposit`/`mint`. This changes the meaning of `_totalPendingDepositAssets`. IMO This is aligned with the lifecycle documented in the ERC
<img width="1050" height="305" alt="image" src="https://github.com/user-attachments/assets/8348c92e-90ad-4529-a4c6-f5887c47237f" />

- remove requestId from the implementation, only supporting the values `0` by default. Supporting more values would require many overrides by the user anyway.

- split public/internal function to guide users in their customization of the vault.

- `_fulfillDeposit` doesn't get exchange rate from a function. Since this rate is likelly to depending on many parameters, it is expected that the public function that will execute the internal fulfill call will itself compute the rate at which the operation is being fulfilled, and will feed that data to the internal function through the args.

### ERC7540Redeem

(overall similar changes as above)

- introduce an `totalPendingRedeemShares` similar to what exists in ERC7540Deposit to track shares that are burned but have not yet been redeemed.