### PR TITLE
Document the signing change for EIP-7702 senders

### DIFF
--- a/.changeset/paymaster-signer-eip7702-delegate-binding.md
+++ b/.changeset/paymaster-signer-eip7702-delegate-binding.md
@@ -1,5 +1,7 @@
 ---
-'openzeppelin-solidity': patch
+'openzeppelin-solidity': minor
 ---
 
-`PaymasterSigner`: Bind the signable digest to the effective EIP-7702 delegate. For senders whose `initCode` starts with the 20-byte `0x7702` marker, the `initCode` component of the digest is now the delegate read from `userOp.sender`'s code (padded with the trailing initialization data), mirroring the `IEntryPoint`'s `userOpHash` computation. Sponsorship signatures for non-EIP-7702 senders are unchanged.
+`PaymasterSigner`: Bind the signable digest to the effective EIP-7702 delegate. For senders whose `initCode` is the 20-byte `0x7702` marker, the `initCode` component of the digest is now the delegate read from `userOp.sender`'s code (followed by the trailing initialization data), mirroring the `IEntryPoint`'s `userOpHash` computation. Sponsorship signatures for non-EIP-7702 senders are unchanged.
+
+This changes the digest that sponsorship signers must produce. Signing services that sponsor EIP-7702 senders must be updated in lockstep with the paymaster: they need to sign the substituted `initCode` (the delegate read from the sender's code) rather than the raw marker, otherwise previously working sponsorship will be rejected. See the paymasters guide for the exact value to sign.

--- a/.changeset/paymaster-signer-eip7702-delegate-binding.md
+++ b/.changeset/paymaster-signer-eip7702-delegate-binding.md
@@ -2,6 +2,4 @@
 'openzeppelin-solidity': minor
 ---
 
-`PaymasterSigner`: Bind the signable digest to the effective EIP-7702 delegate. For senders whose `initCode` is the 20-byte `0x7702` marker, the `initCode` component of the digest is now the delegate read from `userOp.sender`'s code (followed by the trailing initialization data), mirroring the `IEntryPoint`'s `userOpHash` computation. Sponsorship signatures for non-EIP-7702 senders are unchanged.
-
-This changes the digest that sponsorship signers must produce. Signing services that sponsor EIP-7702 senders must be updated in lockstep with the paymaster: they need to sign the substituted `initCode` (the delegate read from the sender's code) rather than the raw marker, otherwise previously working sponsorship will be rejected. See the paymasters guide for the exact value to sign.
+`PaymasterSigner`: For EIP-7702 senders, the signable digest now binds the effective delegate (from `sender.code`) instead of the raw `0x7702` marker, matching the `IEntryPoint`'s `userOpHash`. Sponsorship signers must be updated in lockstep or existing flows break silently; see the paymasters guide.

--- a/docs/modules/ROOT/pages/paymasters.adoc
+++ b/docs/modules/ROOT/pages/paymasters.adoc
@@ -49,6 +49,8 @@ const paymasterVerificationGasLimit = 100_000n;
 const paymasterPostOpGasLimit = 300_000n;
 
 // Sign using EIP-712 typed data
+// NOTE: `initCode` below is the *effective* initCode (see `effectiveInitCode` further down), not
+// `userOp.initCode`. The two only differ for EIP-7702 senders.
 const paymasterSignature = await signer.signTypedData({
   domain: {
     chainId: await signerClient.getChainId(),
@@ -75,7 +77,7 @@ const paymasterSignature = await signer.signTypedData({
   message: {
     sender: userOp.sender,
     nonce: userOp.nonce,
-    initCode: userOp.initCode,
+    initCode: await effectiveInitCode(publicClient, userOp),
     callData: userOp.callData,
     accountGasLimits: userOp.accountGasLimits,
     preVerificationGas: userOp.preVerificationGas,
@@ -87,6 +89,38 @@ const paymasterSignature = await signer.signTypedData({
   },
 });
 ----
+
+[[eip-7702-init-code]]
+=== Signing for EIP-7702 senders
+
+The `initCode` field of the signed struct is not always `userOp.initCode`. For EIP-7702 senders — those whose `initCode` is the 20-byte `0x7702` marker (the two marker bytes followed by 18 zero bytes) — the paymaster substitutes the delegate currently installed at `userOp.sender`, mirroring what the EntryPoint does when it computes `userOpHash`. Signing the raw marker instead would produce a digest the paymaster does not recognize, and the operation would be rejected.
+
+Compute the value to sign with a helper:
+
+[source,typescript]
+----
+import { concat, padHex, size, slice } from "viem";
+
+const EIP7702_INIT_CODE_MARKER = padHex("0x7702", { size: 20, dir: "right" });
+
+async function effectiveInitCode(publicClient, userOp) {
+  const initCode = userOp.initCode ?? "0x";
+
+  // The marker is compared over the full 20 bytes, so bytes 2..19 must be zero (a shorter initCode is
+  // zero-padded). Anything else is a regular factory deployment and is signed as-is — including a
+  // factory address that merely happens to start with 0x7702.
+  const head = padHex(slice(initCode, 0, Math.min(20, size(initCode))), { size: 20, dir: "right" });
+  if (head !== EIP7702_INIT_CODE_MARKER) return initCode;
+
+  // Read the delegate out of the sender's code, stripping the 0xef0100 EIP-7702 prefix
+  const code = await publicClient.getCode({ address: userOp.sender });
+  const delegate = slice(code, 3, 23);
+
+  return size(initCode) > 20 ? concat([delegate, slice(initCode, 20)]) : delegate;
+}
+----
+
+WARNING: Because the delegate is read at validation time, a sponsorship signature issued while one delegate is installed stops being valid once the account owner replaces it. This is deliberate: it prevents a signature obtained for one delegate's behavior from authorizing an operation executed by another. Signing services must therefore read the sender's code when signing rather than caching a digest.
 
 The time window (`validAfter` and `validUntil`) allows you to limit how long the signature remains valid. Once signed, the paymaster data needs to be formatted and attached to the user operation:
 


### PR DESCRIPTION
Stacked on top of `docs/paymaster-signer-eip7702-note` (OpenZeppelin/openzeppelin-contracts#6673). Docs + changeset only — no contract or test changes.

## Why

`PaymasterSigner._signableUserOpHash` now substitutes the effective EIP-7702 delegate for the `initCode` component of the digest. The typed-data struct still declares `bytes initCode`, so nothing about this surfaces at compile time — but the value a signer must put in that field changed. `docs/modules/ROOT/pages/paymasters.adoc` still told integrators to sign `initCode: userOp.initCode`, which for an EIP-7702 sender now yields a digest the paymaster rejects. Every existing signing service that sponsors EIP-7702 senders breaks at runtime, silently.

## Changes

- **`docs/modules/ROOT/pages/paymasters.adoc`** — new `=== Signing for EIP-7702 senders` subsection with an `effectiveInitCode` helper, and the signing example now calls it instead of passing `userOp.initCode`. Includes a warning that a sponsorship signature stops being valid once the delegate is replaced (deliberate), so signing services must read `sender.code` at signing time rather than caching a digest.
- **`.changeset/paymaster-signer-eip7702-delegate-binding.md`** — `patch` → `minor`, plus an explicit note that signing services must be updated in lockstep.

The `GuaranteedUserOperation` example further down the same page is deliberately left alone: it is a separate custom paymaster with its own typehash that hashes `keccak256(userOp.initCode)` in Solidity and signs the raw `initCode` in TS. It is internally consistent and not obliged to mirror `PaymasterSigner`.

## Verification

The helper was checked against the contract rather than written from reading it. The same logic was ported to ethers and `keccak256(effectiveInitCode(...))` compared against `PaymasterSigner._effectiveInitCodeHash` for six inputs — `0x`, `0x77`, `0x7702`, `0x770200`, marker + `deadbeef`, and a nonzero-tail factory address (`0x7702aabb…`). All six match, including the empty and 1-byte edges where the marker comparison relies on zero-padding.

Caveat: the snippet in the docs is viem, matching the rest of the file, and is not executed by CI. The viem and ethers forms are structurally identical (`size`/`slice`/`padHex` vs `dataLength`/`dataSlice`/`zeroPadBytes`), so the translation is mechanical, but it is worth a careful read.

## Open question for the maintainer

The `minor` bump is a judgement call and yours to make. There is no Solidity signature or storage-layout change, so it is not a `major` by the usual test, but it does break working offchain integrations with no compile-time signal. Revert to `patch` if the project treats digest changes differently.